### PR TITLE
Add `raw` image tag to publish action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -45,6 +45,7 @@ jobs:
             type=semver,pattern=v{{major}},suffix=-php${{ matrix.php }}
             type=edge,branch=main,suffix=-php${{ matrix.php }}
             type=ref,event=pr,suffix=-php${{ matrix.php }}
+            type=raw,value=php${{ matrix.php }}
 
       - name: Log in to GHCR.io
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
Added more image tag that can be used for any PHP version as the latest tag.

Eg:
- `ghcr.io/sajtiii/docker-laravel:php8.2`
- `ghcr.io/sajtiii/docker-laravel:php8.3`